### PR TITLE
Add dry-configurable as dependency

### DIFF
--- a/lib/yabeda/statsd/version.rb
+++ b/lib/yabeda/statsd/version.rb
@@ -1,5 +1,5 @@
 module Yabeda
   module Statsd
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/yabeda-statsd.gemspec
+++ b/yabeda-statsd.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dogstatsd-ruby"
+  spec.add_dependency "dry-configurable"
   spec.add_dependency "yabeda"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Since we're using the `dry-confgurable`, it should be added as a dependency to the Gemfile.